### PR TITLE
Fix German translation ("Clip" -> "Cast")

### DIFF
--- a/src/main/resources/youtube/translations/de-rDE/strings.xml
+++ b/src/main/resources/youtube/translations/de-rDE/strings.xml
@@ -210,7 +210,7 @@
     <string name="revanced_hide_captions_button_title">Verstecke \"Untertitel\" Schaltfläche</string>
     <string name="revanced_hide_cast_button_summary_off">Die Cast-Schaltfläche wird angezeigt</string>
     <string name="revanced_hide_cast_button_summary_on">Die Cast-Schaltfläche ist versteckt</string>
-    <string name="revanced_hide_cast_button_title">Verstecke Clip-Schaltfläche</string>
+    <string name="revanced_hide_cast_button_title">Verstecke Cast-Schaltfläche</string>
     <string name="revanced_hide_category_bar_in_search_results_title">Kategorieleiste in den Suchergebnissen ausblenden</string>
     <string name="revanced_hide_category_bar_summary_off">Kategorieleiste wird angezeigt</string>
     <string name="revanced_hide_category_bar_summary_on">Kategorieleiste ist versteckt</string>


### PR DESCRIPTION
Fixed the usage of "Clip" instead of "Cast" in the setting for the revanced_hide_cast_button_title in the German translation