### PR TITLE
fix(YouTube/SponsorBlock) Fix overlapping skip buttons for sponsor and highlight

### DIFF
--- a/src/main/resources/youtube/sponsorblock/outline/layout/inline_sponsor_overlay.xml
+++ b/src/main/resources/youtube/sponsorblock/outline/layout/inline_sponsor_overlay.xml
@@ -6,7 +6,7 @@
         android:contentDescription="@string/sb_skip_button_compact_highlight"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignParentRight="true" android:layout_marginRight="20dp"
+        android:layout_alignParentLeft="true"
         android:layout_alignParentBottom="true"
         android:layout_marginBottom="@dimen/inline_controls_bottom_bar_height"
         android:focusable="true"


### PR DESCRIPTION
Should fix https://github.com/inotia00/ReVanced_Extended/issues/1651

Test it before merging, I can't do that currently 

More explanation [here](https://github.com/inotia00/ReVanced_Extended/issues/1651#issuecomment-1802438781)