### PR TITLE
fix(YouTube/Hide feed components): `Hide Latest videos button` setting does not support tablets

### DIFF
--- a/src/main/kotlin/app/revanced/patches/music/general/components/LayoutComponentsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/music/general/components/LayoutComponentsPatch.kt
@@ -9,7 +9,7 @@ import app.revanced.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.revanced.patcher.patch.PatchException
 import app.revanced.patcher.util.smali.ExternalLabel
 import app.revanced.patches.music.general.components.fingerprints.ChipCloudFingerprint
-import app.revanced.patches.music.general.components.fingerprints.ContentPillInFingerprint
+import app.revanced.patches.music.general.components.fingerprints.ContentPillFingerprint
 import app.revanced.patches.music.general.components.fingerprints.FloatingButtonFingerprint
 import app.revanced.patches.music.general.components.fingerprints.FloatingButtonParentFingerprint
 import app.revanced.patches.music.general.components.fingerprints.HistoryMenuItemFingerprint
@@ -57,7 +57,7 @@ object LayoutComponentsPatch : BaseBytecodePatch(
     compatiblePackages = COMPATIBLE_PACKAGE,
     fingerprints = setOf(
         ChipCloudFingerprint,
-        ContentPillInFingerprint,
+        ContentPillFingerprint,
         FloatingButtonParentFingerprint,
         HistoryMenuItemFingerprint,
         HistoryMenuItemOfflineTabFingerprint,
@@ -208,7 +208,7 @@ object LayoutComponentsPatch : BaseBytecodePatch(
 
         // region patch for hide tap to update button
 
-        ContentPillInFingerprint.resultOrThrow().let {
+        ContentPillFingerprint.resultOrThrow().let {
             it.mutableMethod.apply {
                 addInstructionsWithLabels(
                     0,

--- a/src/main/kotlin/app/revanced/patches/music/general/components/fingerprints/ContentPillFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/music/general/components/fingerprints/ContentPillFingerprint.kt
@@ -2,7 +2,7 @@ package app.revanced.patches.music.general.components.fingerprints
 
 import app.revanced.patcher.fingerprint.MethodFingerprint
 
-internal object ContentPillInFingerprint : MethodFingerprint(
+internal object ContentPillFingerprint : MethodFingerprint(
     returnType = "V",
     strings = listOf("Content pill VE is null")
 )

--- a/src/main/kotlin/app/revanced/patches/youtube/feed/components/FeedComponentsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/feed/components/FeedComponentsPatch.kt
@@ -111,6 +111,7 @@ object FeedComponentsPatch : BaseBytecodePatch(
         mapOf(
             BreakingNewsFingerprint to "hideBreakingNewsShelf",                 // carousel shelf, only used to tablet layout.
             ChannelListSubMenuFingerprint to "hideSubscriptionsChannelSection", // subscriptions channel section
+            ContentPillFingerprint to "hideLatestVideosButton",                 // `tap to update` button
             LatestVideosButtonFingerprint to "hideLatestVideosButton",          // latest videos button
         ).forEach { (fingerprint, methodName) ->
             fingerprint.resultOrThrow().let {
@@ -124,24 +125,6 @@ object FeedComponentsPatch : BaseBytecodePatch(
                         "invoke-static {v$targetRegister}, $FEED_CLASS_DESCRIPTOR->$methodName(Landroid/view/View;)V"
                     )
                 }
-            }
-        }
-
-        // endregion
-
-        // region patch for hide tap to update button (Similar with latest video button)
-
-        ContentPillFingerprint.resultOrThrow().let {
-            it.mutableMethod.apply {
-                addInstructionsWithLabels(
-                    0,
-                    """
-                        invoke-static {}, $FEED_CLASS_DESCRIPTOR->hideLatestVideosButton()Z
-                        move-result v0
-                        if-eqz v0, :show
-                        return-void
-                        """, ExternalLabel("show", getInstruction(0))
-                )
             }
         }
 

--- a/src/main/kotlin/app/revanced/patches/youtube/feed/components/FeedComponentsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/feed/components/FeedComponentsPatch.kt
@@ -18,6 +18,7 @@ import app.revanced.patches.youtube.feed.components.fingerprints.ChannelListSubM
 import app.revanced.patches.youtube.feed.components.fingerprints.ChannelListSubMenuTabletSyntheticFingerprint
 import app.revanced.patches.youtube.feed.components.fingerprints.ChannelTabBuilderFingerprint
 import app.revanced.patches.youtube.feed.components.fingerprints.ChannelTabRendererFingerprint
+import app.revanced.patches.youtube.feed.components.fingerprints.ContentPillFingerprint
 import app.revanced.patches.youtube.feed.components.fingerprints.ElementParserFingerprint
 import app.revanced.patches.youtube.feed.components.fingerprints.ElementParserParentFingerprint
 import app.revanced.patches.youtube.feed.components.fingerprints.EngagementPanelUpdateFingerprint
@@ -78,6 +79,7 @@ object FeedComponentsPatch : BaseBytecodePatch(
         ChannelListSubMenuTabletFingerprint,
         ChannelListSubMenuTabletSyntheticFingerprint,
         ChannelTabRendererFingerprint,
+        ContentPillFingerprint,
         ElementParserParentFingerprint,
         EngagementPanelBuilderFingerprint,
         FilterBarHeightFingerprint,
@@ -122,6 +124,24 @@ object FeedComponentsPatch : BaseBytecodePatch(
                         "invoke-static {v$targetRegister}, $FEED_CLASS_DESCRIPTOR->$methodName(Landroid/view/View;)V"
                     )
                 }
+            }
+        }
+
+        // endregion
+
+        // region patch for hide tap to update button (Similar with latest video button)
+
+        ContentPillFingerprint.resultOrThrow().let {
+            it.mutableMethod.apply {
+                addInstructionsWithLabels(
+                    0,
+                    """
+                        invoke-static {}, $FEED_CLASS_DESCRIPTOR->hideLatestVideosButton()Z
+                        move-result v0
+                        if-eqz v0, :show
+                        return-void
+                        """, ExternalLabel("show", getInstruction(0))
+                )
             }
         }
 

--- a/src/main/kotlin/app/revanced/patches/youtube/feed/components/FeedComponentsPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/feed/components/FeedComponentsPatch.kt
@@ -38,8 +38,13 @@ import app.revanced.patches.youtube.utils.integrations.Constants.FEED_PATH
 import app.revanced.patches.youtube.utils.navigation.NavigationBarHookPatch
 import app.revanced.patches.youtube.utils.playertype.PlayerTypeHookPatch
 import app.revanced.patches.youtube.utils.resourceid.SharedResourceIdPatch
+import app.revanced.patches.youtube.utils.resourceid.SharedResourceIdPatch.Bar
 import app.revanced.patches.youtube.utils.resourceid.SharedResourceIdPatch.CaptionToggleContainer
+import app.revanced.patches.youtube.utils.resourceid.SharedResourceIdPatch.ChannelListSubMenu
+import app.revanced.patches.youtube.utils.resourceid.SharedResourceIdPatch.ContentPill
+import app.revanced.patches.youtube.utils.resourceid.SharedResourceIdPatch.HorizontalCardList
 import app.revanced.patches.youtube.utils.settings.SettingsPatch
+import app.revanced.util.REGISTER_TEMPLATE_REPLACEMENT
 import app.revanced.util.alsoResolve
 import app.revanced.util.getReference
 import app.revanced.util.getWalkerMethod
@@ -47,6 +52,7 @@ import app.revanced.util.indexOfFirstInstruction
 import app.revanced.util.indexOfFirstInstructionOrThrow
 import app.revanced.util.indexOfFirstInstructionReversedOrThrow
 import app.revanced.util.indexOfFirstWideLiteralInstructionValueOrThrow
+import app.revanced.util.injectLiteralInstructionViewCall
 import app.revanced.util.patch.BaseBytecodePatch
 import app.revanced.util.resultOrThrow
 import com.android.tools.smali.dexlib2.Opcode
@@ -108,24 +114,35 @@ object FeedComponentsPatch : BaseBytecodePatch(
 
         // region patch for hide carousel shelf, subscriptions channel section, latest videos button
 
-        mapOf(
-            BreakingNewsFingerprint to "hideBreakingNewsShelf",                 // carousel shelf, only used to tablet layout.
-            ChannelListSubMenuFingerprint to "hideSubscriptionsChannelSection", // subscriptions channel section
-            ContentPillFingerprint to "hideLatestVideosButton",                 // `tap to update` button
-            LatestVideosButtonFingerprint to "hideLatestVideosButton",          // latest videos button
-        ).forEach { (fingerprint, methodName) ->
-            fingerprint.resultOrThrow().let {
-                it.mutableMethod.apply {
-                    val targetIndex = it.scanResult.patternScanResult!!.endIndex
-                    val targetRegister =
-                        getInstruction<OneRegisterInstruction>(targetIndex).registerA
-
-                    addInstruction(
-                        targetIndex + 1,
-                        "invoke-static {v$targetRegister}, $FEED_CLASS_DESCRIPTOR->$methodName(Landroid/view/View;)V"
-                    )
-                }
-            }
+        listOf(
+            // carousel shelf, only used to tablet layout.
+            Triple(
+                BreakingNewsFingerprint,
+                "hideBreakingNewsShelf",
+                HorizontalCardList
+            ),
+            // subscriptions channel section.
+            Triple(
+                ChannelListSubMenuFingerprint,
+                "hideSubscriptionsChannelSection",
+                ChannelListSubMenu
+            ),
+            // latest videos button
+            Triple(
+                ContentPillFingerprint,
+                "hideLatestVideosButton",
+                ContentPill
+            ),
+            Triple(
+                LatestVideosButtonFingerprint,
+                "hideLatestVideosButton",
+                Bar
+            ),
+        ).forEach { (fingerprint, methodName, literal) ->
+            val smaliInstruction = """
+                    invoke-static {v$REGISTER_TEMPLATE_REPLACEMENT}, $FEED_CLASS_DESCRIPTOR->$methodName(Landroid/view/View;)V
+                    """
+            fingerprint.injectLiteralInstructionViewCall(literal, smaliInstruction)
         }
 
         // endregion

--- a/src/main/kotlin/app/revanced/patches/youtube/feed/components/fingerprints/BreakingNewsFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/feed/components/fingerprints/BreakingNewsFingerprint.kt
@@ -4,15 +4,8 @@ import app.revanced.patcher.extensions.or
 import app.revanced.patches.youtube.utils.resourceid.SharedResourceIdPatch.HorizontalCardList
 import app.revanced.util.fingerprint.LiteralValueFingerprint
 import com.android.tools.smali.dexlib2.AccessFlags
-import com.android.tools.smali.dexlib2.Opcode
 
 internal object BreakingNewsFingerprint : LiteralValueFingerprint(
     accessFlags = AccessFlags.PUBLIC or AccessFlags.CONSTRUCTOR,
-    opcodes = listOf(
-        Opcode.CONST,
-        Opcode.CONST_4,
-        Opcode.INVOKE_VIRTUAL,
-        Opcode.MOVE_RESULT_OBJECT
-    ),
-    literalSupplier = { HorizontalCardList }
+    literalSupplier = { HorizontalCardList },
 )

--- a/src/main/kotlin/app/revanced/patches/youtube/feed/components/fingerprints/ChannelListSubMenuFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/feed/components/fingerprints/ChannelListSubMenuFingerprint.kt
@@ -2,14 +2,7 @@ package app.revanced.patches.youtube.feed.components.fingerprints
 
 import app.revanced.patches.youtube.utils.resourceid.SharedResourceIdPatch.ChannelListSubMenu
 import app.revanced.util.fingerprint.LiteralValueFingerprint
-import com.android.tools.smali.dexlib2.Opcode
 
 internal object ChannelListSubMenuFingerprint : LiteralValueFingerprint(
-    opcodes = listOf(
-        Opcode.CONST,
-        Opcode.CONST_4,
-        Opcode.INVOKE_VIRTUAL,
-        Opcode.MOVE_RESULT_OBJECT
-    ),
-    literalSupplier = { ChannelListSubMenu }
+    literalSupplier = { ChannelListSubMenu },
 )

--- a/src/main/kotlin/app/revanced/patches/youtube/feed/components/fingerprints/ContentPillFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/feed/components/fingerprints/ContentPillFingerprint.kt
@@ -1,0 +1,8 @@
+package app.revanced.patches.youtube.feed.components.fingerprints
+
+import app.revanced.patcher.fingerprint.MethodFingerprint
+
+internal object ContentPillFingerprint : MethodFingerprint(
+    returnType = "V",
+    strings = listOf("Controller must be initialized for a feed before the content pill can be shown.")
+)

--- a/src/main/kotlin/app/revanced/patches/youtube/feed/components/fingerprints/ContentPillFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/feed/components/fingerprints/ContentPillFingerprint.kt
@@ -4,17 +4,10 @@ import app.revanced.patcher.extensions.or
 import app.revanced.patches.youtube.utils.resourceid.SharedResourceIdPatch.ContentPill
 import app.revanced.util.fingerprint.LiteralValueFingerprint
 import com.android.tools.smali.dexlib2.AccessFlags
-import com.android.tools.smali.dexlib2.Opcode
 
 internal object ContentPillFingerprint : LiteralValueFingerprint(
     returnType = "V",
     accessFlags = AccessFlags.PUBLIC or AccessFlags.FINAL,
     parameters = listOf("L", "Z"),
-    opcodes = listOf(
-        Opcode.CONST,
-        Opcode.IGET_OBJECT,
-        Opcode.INVOKE_VIRTUAL,
-        Opcode.MOVE_RESULT_OBJECT
-    ),
-    literalSupplier = { ContentPill }
+    literalSupplier = { ContentPill },
 )

--- a/src/main/kotlin/app/revanced/patches/youtube/feed/components/fingerprints/ContentPillFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/feed/components/fingerprints/ContentPillFingerprint.kt
@@ -1,8 +1,20 @@
 package app.revanced.patches.youtube.feed.components.fingerprints
 
-import app.revanced.patcher.fingerprint.MethodFingerprint
+import app.revanced.patcher.extensions.or
+import app.revanced.patches.youtube.utils.resourceid.SharedResourceIdPatch.ContentPill
+import app.revanced.util.fingerprint.LiteralValueFingerprint
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
 
-internal object ContentPillFingerprint : MethodFingerprint(
+internal object ContentPillFingerprint : LiteralValueFingerprint(
     returnType = "V",
-    strings = listOf("Controller must be initialized for a feed before the content pill can be shown.")
+    accessFlags = AccessFlags.PUBLIC or AccessFlags.FINAL,
+    parameters = listOf("L", "Z"),
+    opcodes = listOf(
+        Opcode.CONST,
+        Opcode.IGET_OBJECT,
+        Opcode.INVOKE_VIRTUAL,
+        Opcode.MOVE_RESULT_OBJECT
+    ),
+    literalSupplier = { ContentPill }
 )

--- a/src/main/kotlin/app/revanced/patches/youtube/feed/components/fingerprints/LatestVideosButtonFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/feed/components/fingerprints/LatestVideosButtonFingerprint.kt
@@ -4,17 +4,10 @@ import app.revanced.patcher.extensions.or
 import app.revanced.patches.youtube.utils.resourceid.SharedResourceIdPatch.Bar
 import app.revanced.util.fingerprint.LiteralValueFingerprint
 import com.android.tools.smali.dexlib2.AccessFlags
-import com.android.tools.smali.dexlib2.Opcode
 
 internal object LatestVideosButtonFingerprint : LiteralValueFingerprint(
     returnType = "V",
     accessFlags = AccessFlags.PUBLIC or AccessFlags.FINAL,
     parameters = listOf("L", "Z"),
-    opcodes = listOf(
-        Opcode.CONST,
-        Opcode.IGET_OBJECT,
-        Opcode.INVOKE_VIRTUAL,
-        Opcode.MOVE_RESULT_OBJECT
-    ),
-    literalSupplier = { Bar }
+    literalSupplier = { Bar },
 )

--- a/src/main/kotlin/app/revanced/patches/youtube/utils/resourceid/SharedResourceIdPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/utils/resourceid/SharedResourceIdPatch.kt
@@ -42,6 +42,7 @@ object SharedResourceIdPatch : ResourcePatch() {
     var CompactLink = -1L
     var CompactListItem = -1L
     var ComponentLongClickListener = -1L
+    var ContentPill = -1L
     var ControlsLayoutStub = -1L
     var DarkBackground = -1L
     var DarkSplashAnimation = -1L
@@ -150,6 +151,7 @@ object SharedResourceIdPatch : ResourcePatch() {
         CompactLink = getId(LAYOUT, "compact_link")
         CompactListItem = getId(LAYOUT, "compact_list_item")
         ComponentLongClickListener = getId(ID, "component_long_click_listener")
+        ContentPill = getId(LAYOUT, "content_pill")
         ControlsLayoutStub = getId(ID, "controls_layout_stub")
         DarkBackground = getId(ID, "dark_background")
         DarkSplashAnimation = getId(ID, "dark_splash_animation")


### PR DESCRIPTION
The `Tap to update` button in Youtube is similar with the button in https://github.com/inotia00/ReVanced_Extended/issues/1880.

Since the `Tap to update` and `Latest video` button have the same function, I think splitting into a new setting is unnecessary