### PR TITLE
feat(YouTube - Hide Video Chapter): Add `Hide video chapter` patch

### DIFF
--- a/src/main/kotlin/app/revanced/patches/youtube/general/chapter/DisableVideoChapterPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/general/chapter/DisableVideoChapterPatch.kt
@@ -23,7 +23,7 @@ object DisableVideoChapterPatch : BaseBytecodePatch(
         TimelineMarkerArrayFingerprint.resultOrThrow().mutableMethod.addInstructionsWithLabels(
             0,
             """
-                invoke-static {}, $PLAYER_CLASS_DESCRIPTOR->disableVideoChapter()Z
+                invoke-static {}, $GENERAL_CLASS_DESCRIPTOR->disableVideoChapter()Z
                 move-result v0
                 if-eqz v0, :show_chapter
 

--- a/src/main/kotlin/app/revanced/patches/youtube/general/chapter/DisableVideoChapterPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/general/chapter/DisableVideoChapterPatch.kt
@@ -1,0 +1,50 @@
+package app.revanced.patches.youtube.general.chapter
+
+import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
+import app.revanced.patcher.util.smali.ExternalLabel
+import app.revanced.patches.youtube.general.chapter.fingerprints.TimelineMarkerArrayFingerprint
+import app.revanced.patches.youtube.utils.compatibility.Constants.COMPATIBLE_PACKAGE
+import app.revanced.patches.youtube.utils.integrations.Constants.GENERAL_CLASS_DESCRIPTOR
+import app.revanced.patches.youtube.utils.settings.SettingsPatch
+import app.revanced.util.patch.BaseBytecodePatch
+import app.revanced.util.resultOrThrow
+
+@Suppress("unused")
+object DisableVideoChapterPatch : BaseBytecodePatch(
+    name = "Disable video chapter",
+    description = "Adds an option to disable video chapter.",
+    dependencies = setOf(SettingsPatch::class),
+    compatiblePackages = COMPATIBLE_PACKAGE,
+    fingerprints = setOf(TimelineMarkerArrayFingerprint)
+) {
+    override fun execute(context: BytecodeContext) {
+
+        TimelineMarkerArrayFingerprint.resultOrThrow().mutableMethod.addInstructionsWithLabels(
+            0,
+            """
+                invoke-static {}, $PLAYER_CLASS_DESCRIPTOR->disableVideoChapter()Z
+                move-result v0
+                if-eqz v0, :show_chapter
+
+                # Create an empty array
+                const/4 v0, 0x0
+                new-array p1, v0, [Lcom/google/android/libraries/youtube/player/features/overlay/timebar/TimelineMarker;
+                return-object p1
+            """,
+            ExternalLabel("show_chapter", getInstruction(0)),
+        )
+
+        /**
+         * Add settings
+         */
+        SettingsPatch.addPreference(
+            arrayOf(
+                "PREFERENCE_SCREEN: GENERAL",
+                "SETTINGS: DISABLE_VIDEO_CHAPTER"
+            )
+        )
+
+        SettingsPatch.updatePatchStatus(this)
+    }
+}

--- a/src/main/kotlin/app/revanced/patches/youtube/general/chapter/fingerprints/TimelineMarkerArrayFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patches/youtube/general/chapter/fingerprints/TimelineMarkerArrayFingerprint.kt
@@ -1,0 +1,10 @@
+package app.revanced.patches.youtube.general.chapter.fingerprints
+
+import app.revanced.patcher.extensions.or
+import app.revanced.patcher.fingerprint.MethodFingerprint
+import com.android.tools.smali.dexlib2.AccessFlags
+
+internal object TimelineMarkerArrayFingerprint : MethodFingerprint(
+    returnType = "[Lcom/google/android/libraries/youtube/player/features/overlay/timebar/TimelineMarker;",
+    accessFlags = AccessFlags.PUBLIC or AccessFlags.FINAL,
+)

--- a/src/main/resources/youtube/settings/host/values/strings.xml
+++ b/src/main/resources/youtube/settings/host/values/strings.xml
@@ -344,6 +344,9 @@ Limitation: Back button on the toolbar may not work."</string>
     <string name="revanced_disable_auto_captions_title">Disable forced auto captions</string>
     <string name="revanced_disable_auto_captions_summary_on">Forced auto captions are disabled.</string>
     <string name="revanced_disable_auto_captions_summary_off">Forced auto captions are enabled.</string>
+    <string name="revanced_disable_video_chapter_title">Disable video chapter</string>
+    <string name="revanced_disable_video_chapter_summary_on">Video chapter are disabled.</string>
+    <string name="revanced_disable_video_chapter_summary_off">Video chapter are enabled.</string>
     <string name="revanced_disable_splash_animation_title">Disable splash animation</string>
     <string name="revanced_disable_splash_animation_summary_on">Splash animation is disabled.</string>
     <string name="revanced_disable_splash_animation_summary_off">Splash animation is enabled.</string>

--- a/src/main/resources/youtube/settings/xml/revanced_prefs.xml
+++ b/src/main/resources/youtube/settings/xml/revanced_prefs.xml
@@ -253,6 +253,9 @@
 
         <!-- SETTINGS: DISABLE_AUTO_CAPTIONS
         <SwitchPreference android:title="@string/revanced_disable_auto_captions_title" android:key="revanced_disable_auto_captions" android:summaryOn="@string/revanced_disable_auto_captions_summary_on" android:summaryOff="@string/revanced_disable_auto_captions_summary_off" />SETTINGS: DISABLE_AUTO_CAPTIONS -->
+    
+        <!-- SETTINGS: DISABLE_VIDEO_CHAPTER
+        <SwitchPreference android:title="@string/revanced_disable_video_chapter_title" android:key="revanced_disable_video_chapter" android:summaryOn="@string/revanced_disable_video_chapter_summary_on" android:summaryOff="@string/revanced_disable_video_chapter_summary_off" />SETTINGS: DISABLE_VIDEO_CHAPTER -->
 
         <!-- SETTINGS: DISABLE_SPLASH_ANIMATION
         <SwitchPreference android:title="@string/revanced_disable_splash_animation_title" android:key="revanced_disable_splash_animation" android:summaryOn="@string/revanced_disable_splash_animation_summary_on" android:summaryOff="@string/revanced_disable_splash_animation_summary_off" />SETTINGS: DISABLE_SPLASH_ANIMATION -->


### PR DESCRIPTION
Related issues: https://github.com/inotia00/ReVanced_Extended/issues/1984

Todo:
- [ ] Find a suitable hook to prevent heatmap deletion
- [ ] Add integrations
- [ ] Feed seek forward button isn't hidden
- [ ] Add a toggle to hide `Seek forward button in feed`
- [ ] Implement `SponsorBlock Chapter` support (Maybe with another PR)
<details>

![image](https://github.com/user-attachments/assets/243547de-f2be-4e5f-9da0-f54405e1b732)

</details>

## Will do it soon, right now I'm prepairing for my exam 😭😭😭