### PR TITLE
ci: Use semi-transparent Discord embed color

### DIFF
--- a/.github/workflows/discord_ping_on_release.yml
+++ b/.github/workflows/discord_ping_on_release.yml
@@ -10,13 +10,33 @@ jobs:
     steps:
       - uses: sarisia/actions-status-discord@v1
         if: always()
+        id: webhook # set id to reference output payload later
         with:
-          webhook: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          username: ReVanced Extended
-          color: 0xff5252
+          ack_no_webhook: true # suppress warning
           nodetail: true
           notimestamp: true
+          
+          username: ReVanced Extended
           content: "<@&1271197877724643461>"
           title: "Patches `${{ github.event.release.tag_name }}` has been released!"
           description: |
             Click [here](${{ github.event.release.html_url }}) to read the changelog and release notes.
+
+      - run: npm install axios
+      - uses: actions/github-script@v7
+        env:
+          WEBHOOK_PAYLOAD: ${{ steps.webhook.outputs.payload }}
+          WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        with:
+          script: |
+            const axios = require("axios")
+
+            const { WEBHOOK_PAYLOAD, WEBHOOK_URL } = process.env
+
+            const payload = JSON.parse(WEBHOOK_PAYLOAD)
+
+            // remove the color field to make it transparent
+            delete payload.embeds[0].color
+
+            // send to Discord 
+            axios.post(WEBHOOK_URL, payload)


### PR DESCRIPTION
This change makes it so that the accent color of Discord embeds will be semi-transparent (and therefore follow the user's theme) instead of opaque RVX-red. The rest of the embeds in the server use the semi-transparent color because it is easier on the eyes and looks more professional.

This image shows the difference:

<img src="https://github.com/user-attachments/assets/f8ae74d2-187b-4ea4-ad40-bbde971e4622" width=400>

The semi-transparent color is displayed when the `color` field in the payload JSON is undefined or set to `null`.  Unfortunately, the [GitHub action](https://github.com/marketplace/actions/actions-status-discord) that this workflow uses does not allow you to simply leave the `color` field undefined or set to `null`. (If this is attempted, the color will default to green for some reason). To get around this, the creator of the GitHub action added the ability to generate the payload without sending it, which allows you to edit it and then send it afterward.

See https://github.com/sarisia/actions-status-discord/discussions/547 for further discussion.