### PR TITLE
feat(YouTube - Snack bar components): Add patch option `Apply corner radius to playlist bottom bar`

### DIFF
--- a/patches/src/main/kotlin/app/revanced/patches/youtube/general/snackbar/SnackBarComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/youtube/general/snackbar/SnackBarComponentsPatch.kt
@@ -326,6 +326,18 @@ val snackBarComponentsPatch = resourcePatch(
             }
         }
 
+        document("res/values/dimens.xml").use { document ->
+            document.getElementsByTagName("dimen")
+            .first { it.getAttribute("name") == "snackbar_corner_radius" }
+            .textContent = cornerRadius
+        }
+
+        document("res/drawable/playlist_entry_point_corner_drawable.xml").use { document ->
+            document.getNode("corners").apply {
+                attributes.getNamedItem("android:radius").nodeValue = cornerRadius
+            }
+        }
+
         // region add settings
 
         addPreference(

--- a/patches/src/main/kotlin/app/revanced/patches/youtube/general/snackbar/SnackBarComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/youtube/general/snackbar/SnackBarComponentsPatch.kt
@@ -327,9 +327,16 @@ val snackBarComponentsPatch = resourcePatch(
         }
 
         document("res/values/dimens.xml").use { document ->
-            document.getElementsByTagName("dimen")
-            .first { it.getAttribute("name") == "snackbar_corner_radius" }
-            .textContent = cornerRadius
+            val resourcesNode = document.getElementsByTagName("resources").item(0) as Element
+
+            for (i in 0 until resourcesNode.childNodes.length) {
+                val node = resourcesNode.childNodes.item(i) as? Element ?: continue
+                val dimenName = node.getAttribute("name")
+
+                if (dimenName.equals("snackbar_corner_radius")) {
+                    node.textContent = cornerRadius
+                }
+            }
         }
 
         document("res/drawable/playlist_entry_point_corner_drawable.xml").use { document ->

--- a/patches/src/main/kotlin/app/revanced/patches/youtube/general/snackbar/SnackBarComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/youtube/general/snackbar/SnackBarComponentsPatch.kt
@@ -5,6 +5,7 @@ import app.revanced.patcher.extensions.InstructionExtensions.addInstructions
 import app.revanced.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
 import app.revanced.patcher.extensions.InstructionExtensions.getInstruction
 import app.revanced.patcher.extensions.InstructionExtensions.replaceInstruction
+import app.revanced.patcher.patch.booleanOption
 import app.revanced.patcher.patch.bytecodePatch
 import app.revanced.patcher.patch.resourcePatch
 import app.revanced.patcher.patch.stringOption
@@ -212,6 +213,14 @@ val snackBarComponentsPatch = resourcePatch(
         required = true,
     )
 
+    val applyCornerRadiusToPlaylistBottomBarOption by booleanOption(
+        key = "applyCornerRadiusToPlaylistBottomBar",
+        default = false,
+        title = "Apply corner radius to playlist bottom bar",
+        description = "Whether to apply the same corner radius to the bottom bar of the playlist as the snack bar.",
+        required = true
+    )
+
     val darkThemeBackgroundColor = stringOption(
         key = "darkThemeBackgroundColor",
         default = ytBackgroundColorDark,
@@ -248,6 +257,8 @@ val snackBarComponentsPatch = resourcePatch(
         // Check patch options first.
         val cornerRadius = cornerRadiusOption
             .valueOrThrow()
+        val applyCornerRadiusToPlaylistBottomBar =
+            applyCornerRadiusToPlaylistBottomBarOption == true
         val darkThemeColor = darkThemeBackgroundColor
             .valueOrThrow()
         val lightThemeColor = lightThemeBackgroundColor
@@ -339,9 +350,11 @@ val snackBarComponentsPatch = resourcePatch(
             }
         }
 
-        document("res/drawable/playlist_entry_point_corner_drawable.xml").use { document ->
-            document.getNode("corners").apply {
-                attributes.getNamedItem("android:radius").nodeValue = cornerRadius
+        if (applyCornerRadiusToPlaylistBottomBar) {
+            document("res/drawable/playlist_entry_point_corner_drawable.xml").use { document ->
+                document.getNode("corners").apply {
+                    attributes.getNamedItem("android:radius").nodeValue = cornerRadius
+                }
             }
         }
 


### PR DESCRIPTION
add radius for under player snackbar e.g. change quality, ambient mode on/off and playlist for uniformity
![photo_6109403473629005643_x](https://github.com/user-attachments/assets/0d2de50d-a2f1-4e09-badb-6a4acf76a48d)
not added color for playlist as it use translucent bg
the snackbar radius in yt settings snackbar not change despite this pr