### PR TITLE
refactor: Improve XML performance

### DIFF
--- a/patches/src/main/kotlin/app/revanced/patches/music/layout/theme/DarkThemePatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/music/layout/theme/DarkThemePatch.kt
@@ -112,10 +112,11 @@ val darkThemePatch = resourcePatch(
             .valueOrThrow()
 
         document("res/values/colors.xml").use { document ->
-            val resourcesNode = document.getElementsByTagName("resources").item(0) as Element
+            val resourcesNode = document.documentElement
+            val childNodes = resourcesNode.childNodes
 
-            for (i in 0 until resourcesNode.childNodes.length) {
-                val node = resourcesNode.childNodes.item(i) as? Element ?: continue
+            for (i in 0 until childNodes.length) {
+                val node = childNodes.item(i) as? Element ?: continue
                 val colorName = node.getAttribute("name")
 
                 if (DARK_COLOR.contains(colorName)) {

--- a/patches/src/main/kotlin/app/revanced/patches/shared/materialyou/BaseMaterialYouPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/shared/materialyou/BaseMaterialYouPatch.kt
@@ -37,8 +37,9 @@ private fun ResourcePatchContext.patchXmlFile(
         val parentList = document.getElementsByTagName(parentNode).item(0) as Element
 
         if (targetNode != null) {
-            for (i in 0 until parentList.childNodes.length) {
-                val node = parentList.childNodes.item(i) as? Element ?: continue
+            val childNodes = parentList.childNodes
+            for (i in 0 until childNodes.length) {
+                val node = childNodes.item(i) as? Element ?: continue
 
                 if (node.nodeName == targetNode && node.hasAttribute(attribute)) {
                     node.getAttributeNode(attribute).textContent = newValue

--- a/patches/src/main/kotlin/app/revanced/patches/shared/translations/BaseTranslationsPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/shared/translations/BaseTranslationsPatch.kt
@@ -123,35 +123,34 @@ fun ResourcePatchContext.baseTranslationsPatch(
     }.toHashSet().toTypedArray()
 
     // Remove unselected app languages from RVX Settings
-    setOf(
-        "revanced_language_entries",
-        "revanced_language_entry_values",
-    ).forEach { attributeName ->
-        document("res/values/arrays.xml").use { document ->
-            with(document) {
-                val nodesToRemove = mutableListOf<Node>()
+    document("res/values/arrays.xml").use { document ->
+        val targetAttributeNames = setOf(
+            "revanced_language_entries",
+            "revanced_language_entry_values",
+        )
+        val nodesToRemove = mutableListOf<Node>()
 
-                val resourcesNode = getElementsByTagName("resources").item(0) as Element
-                for (i in 0 until resourcesNode.childNodes.length) {
-                    val node = resourcesNode.childNodes.item(i) as? Element ?: continue
+        val resourcesNode = document.documentElement
+        val childNodes = resourcesNode.childNodes
+        for (i in 0 until childNodes.length) {
+            val node = childNodes.item(i) as? Element ?: continue
 
-                    if (node.getAttribute("name") == attributeName) {
-                        for (j in 0 until node.childNodes.length) {
-                            val item = node.childNodes.item(j) as? Element ?: continue
-                            val text = item.textContent
-                            val length = text.length
-                            if (!text.endsWith("DEFAULT") && text.subSequence(length - 2, length) !in filteredAppLanguages) {
-                                nodesToRemove.add(item)
-                            }
-                        }
+            if (node.getAttribute("name") in targetAttributeNames) {
+                val itemNodes = node.childNodes
+                for (j in 0 until itemNodes.length) {
+                    val item = itemNodes.item(j) as? Element ?: continue
+                    val text = item.textContent
+                    val length = text.length
+                    if (!text.endsWith("DEFAULT") && text.subSequence(length - 2, length) !in filteredAppLanguages) {
+                        nodesToRemove.add(item)
                     }
                 }
-
-                // Remove the collected nodes (avoids NullPointerException)
-                for (n in nodesToRemove) {
-                    n.parentNode?.removeChild(n)
-                }
             }
+        }
+
+        // Remove the collected nodes (avoids NullPointerException)
+        for (n in nodesToRemove) {
+            n.parentNode?.removeChild(n)
         }
     }
 }

--- a/patches/src/main/kotlin/app/revanced/patches/youtube/general/snackbar/SnackBarComponentsPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/youtube/general/snackbar/SnackBarComponentsPatch.kt
@@ -348,14 +348,16 @@ val snackBarComponentsPatch = resourcePatch(
         }
 
         document("res/values/dimens.xml").use { document ->
-            val resourcesNode = document.getElementsByTagName("resources").item(0) as Element
+            val resourcesNode = document.documentElement
+            val childNodes = resourcesNode.childNodes
 
-            for (i in 0 until resourcesNode.childNodes.length) {
-                val node = resourcesNode.childNodes.item(i) as? Element ?: continue
+            for (i in 0 until childNodes.length) {
+                val node = childNodes.item(i) as? Element ?: continue
                 val dimenName = node.getAttribute("name")
 
                 if (dimenName.equals("snackbar_corner_radius")) {
                     node.textContent = cornerRadius
+                    break
                 }
             }
         }

--- a/patches/src/main/kotlin/app/revanced/patches/youtube/layout/theme/ThemePatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/youtube/layout/theme/ThemePatch.kt
@@ -77,10 +77,11 @@ val themePatch = resourcePatch(
 
         arrayOf("values", "values-v31").forEach { path ->
             document("res/$path/colors.xml").use { document ->
-                val resourcesNode = document.getElementsByTagName("resources").item(0) as Element
+                val resourcesNode = document.documentElement
+                val childNodes = resourcesNode.childNodes
 
-                for (i in 0 until resourcesNode.childNodes.length) {
-                    val node = resourcesNode.childNodes.item(i) as? Element ?: continue
+                for (i in 0 until childNodes.length) {
+                    val node = childNodes.item(i) as? Element ?: continue
 
                     node.textContent = when (node.getAttribute("name")) {
                         "yt_black0", "yt_black1", "yt_black1_opacity95", "yt_black1_opacity98", "yt_black2", "yt_black3",

--- a/patches/src/main/kotlin/app/revanced/patches/youtube/utils/settings/SettingsPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/youtube/utils/settings/SettingsPatch.kt
@@ -223,22 +223,21 @@ val settingsPatch = resourcePatch(
         /**
          * remove ReVanced Extended Settings divider
          */
-        arrayOf("Theme.YouTube.Settings", "Theme.YouTube.Settings.Dark").forEach { themeName ->
-            document("res/values/styles.xml").use { document ->
-                with(document) {
-                    val resourcesNode = getElementsByTagName("resources").item(0) as Element
+        document("res/values/styles.xml").use { document ->
+            val themeNames = arrayOf("Theme.YouTube.Settings", "Theme.YouTube.Settings.Dark")
+            with(document) {
+                val resourcesNode = documentElement
+                val childNodes = resourcesNode.childNodes
 
-                    val newElement: Element = createElement("item")
-                    newElement.setAttribute("name", "android:listDivider")
+                for (i in 0 until childNodes.length) {
+                    val node = childNodes.item(i) as? Element ?: continue
 
-                    for (i in 0 until resourcesNode.childNodes.length) {
-                        val node = resourcesNode.childNodes.item(i) as? Element ?: continue
-
-                        if (node.getAttribute("name") == themeName) {
-                            newElement.appendChild(createTextNode("@null"))
-
-                            node.appendChild(newElement)
+                    if (node.getAttribute("name") in themeNames) {
+                        val newElement = createElement("item").apply {
+                            setAttribute("name", "android:listDivider")
+                            appendChild(createTextNode("@null"))
                         }
+                        node.appendChild(newElement)
                     }
                 }
             }

--- a/patches/src/main/kotlin/app/revanced/util/ResourceUtils.kt
+++ b/patches/src/main/kotlin/app/revanced/util/ResourceUtils.kt
@@ -55,7 +55,8 @@ fun Node.cloneNodes(parent: Node) {
  */
 fun Node.doRecursively(action: (Node) -> Unit) {
     action(this)
-    for (i in 0 until this.childNodes.length) this.childNodes.item(i).doRecursively(action)
+    val childNodes = this.childNodes
+    for (i in 0 until childNodes.length) childNodes.item(i).doRecursively(action)
 }
 
 fun List<String>.getResourceGroup(fileNames: Array<String>) = map { directory ->
@@ -164,10 +165,11 @@ fun ResourcePatchContext.addEntryValues(
 ) {
     document(path).use { document ->
         with(document) {
-            val resourcesNode = getElementsByTagName("resources").item(0) as Element
+            val resourcesNode = documentElement
+            val childNodes = resourcesNode.childNodes
             val newElement: Element = createElement("item")
-            for (i in 0 until resourcesNode.childNodes.length) {
-                val node = resourcesNode.childNodes.item(i) as? Element ?: continue
+            for (i in 0 until childNodes.length) {
+                val node = childNodes.item(i) as? Element ?: continue
 
                 if (node.getAttribute("name") == attributeName) {
                     newElement.appendChild(createTextNode(attributeValue))
@@ -177,6 +179,7 @@ fun ResourcePatchContext.addEntryValues(
                     } else {
                         node.insertBefore(newElement, node.firstChild)
                     }
+                    break
                 }
             }
         }


### PR DESCRIPTION
Improve the performance of XML operations by not calling `node.getChildNodes()` multiple times in a loop.

The result of `node.getChildNodes()` should be stored in a variable before starting a for loop.

I compared the performance before PR and after PR, using a Snapdragon 662+4GB RAM phone and a Snapdragon 410+2GB RAM phone
This resulted in significant improvements for some XML files, especially those with many child nodes.

```
https://github.com/inotia00/revanced-patches/blob/b1776cf00729216c001a8dc6720468c08666936d/patches/src/main/kotlin/app/revanced/patches/youtube/layout/theme/ThemePatch.kt#L79-L90
[res/values/colors.xml]
SD662: 637 ms -> 3 ms
SD410: 2971 ms -> 6 ms

https://github.com/inotia00/revanced-patches/blob/b1776cf00729216c001a8dc6720468c08666936d/patches/src/main/kotlin/app/revanced/patches/youtube/utils/settings/SettingsPatch.kt#L227-L244
[res/values/styles.xml]
SD662: 1107 ms -> 10 ms
SD410: 6401 ms -> 35 ms

https://github.com/inotia00/revanced-patches/blob/b1776cf00729216c001a8dc6720468c08666936d/patches/src/main/kotlin/app/revanced/patches/youtube/general/snackbar/SnackBarComponentsPatch.kt#L350-L361
[res/values/dimens.xml]
SD662: 4837 ms -> 11 ms
SD410: 24929 ms -> 13 ms
```

In addition, I did some refactoring:

- Usually, to get the root node of a document, use `document.getDocumentElement()`
- Avoid iterating one XML twice
- break a for loop if possible

I tested this change with 19.44.36, 19.16.36, and 18.29.36 and confirmed that this changes don't change the result resources.
I compared the `patched-temporary-files` dir of current patches and my PR branch patches using WinMerge and those were identical.