### PR TITLE
feat(YouTube Music): Support patching on Android 5-7

### DIFF
--- a/patches/src/main/kotlin/app/revanced/patches/music/layout/branding/icon/CustomBrandingIconPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/music/layout/branding/icon/CustomBrandingIconPatch.kt
@@ -11,6 +11,7 @@ import app.revanced.patches.music.utils.playservice.versionCheckPatch
 import app.revanced.patches.music.utils.settings.ResourceUtils.setIconType
 import app.revanced.patches.music.utils.settings.ResourceUtils.updatePatchStatus
 import app.revanced.patches.music.utils.settings.settingsPatch
+import app.revanced.util.FilesCompat
 import app.revanced.util.ResourceGroup
 import app.revanced.util.Utils.trimIndentMultiline
 import app.revanced.util.copyAdaptiveIcon
@@ -20,7 +21,6 @@ import app.revanced.util.underBarOrThrow
 import app.revanced.util.valueOrThrow
 import org.w3c.dom.Element
 import java.io.File
-import java.nio.file.Files
 
 private const val ADAPTIVE_ICON_BACKGROUND_FILE_NAME =
     "adaptiveproduct_youtube_music_background_color_108"
@@ -155,9 +155,9 @@ val customBrandingIconPatch = resourcePatch(
                         val toDirectory = resourceDirectory.resolve(group.resourceDirectoryName)
 
                         group.resources.forEach { iconFileName ->
-                            Files.write(
-                                toDirectory.resolve(iconFileName).toPath(),
-                                fromDirectory.resolve(iconFileName).readBytes()
+                            FilesCompat.copy(
+                                fromDirectory.resolve(iconFileName),
+                                toDirectory.resolve(iconFileName)
                             )
                         }
                     }

--- a/patches/src/main/kotlin/app/revanced/patches/shared/materialyou/BaseMaterialYouPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/shared/materialyou/BaseMaterialYouPatch.kt
@@ -1,8 +1,8 @@
 package app.revanced.patches.shared.materialyou
 
 import app.revanced.patcher.patch.ResourcePatchContext
+import app.revanced.util.FilesCompat
 import org.w3c.dom.Element
-import java.nio.file.Files
 
 private fun ResourcePatchContext.patchXmlFile(
     fromDir: String,
@@ -17,7 +17,7 @@ private fun ResourcePatchContext.patchXmlFile(
     val fromDirectory = resourceDirectory.resolve(fromDir)
     val toDirectory = resourceDirectory.resolve(toDir)
 
-    if (!toDirectory.isDirectory) Files.createDirectories(toDirectory.toPath())
+    if (!toDirectory.isDirectory) toDirectory.mkdirs()
 
     val fromXmlFile = fromDirectory.resolve(xmlFileName)
     val toXmlFile = toDirectory.resolve(xmlFileName)
@@ -27,9 +27,9 @@ private fun ResourcePatchContext.patchXmlFile(
     }
 
     if (!toXmlFile.exists()) {
-        Files.copy(
-            fromXmlFile.toPath(),
-            toXmlFile.toPath()
+        FilesCompat.copy(
+            fromXmlFile,
+            toXmlFile
         )
     }
 

--- a/patches/src/main/kotlin/app/revanced/patches/shared/translations/BaseTranslationsPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/shared/translations/BaseTranslationsPatch.kt
@@ -2,13 +2,12 @@ package app.revanced.patches.shared.translations
 
 import app.revanced.patcher.patch.PatchException
 import app.revanced.patcher.patch.ResourcePatchContext
+import app.revanced.util.FilesCompat
 import app.revanced.util.doRecursively
 import app.revanced.util.inputStreamFromBundledResource
 import org.w3c.dom.Element
 import org.w3c.dom.Node
 import java.io.File
-import java.nio.file.Files
-import java.nio.file.StandardCopyOption
 import javax.xml.parsers.DocumentBuilderFactory
 import javax.xml.transform.OutputKeys
 import javax.xml.transform.TransformerFactory
@@ -174,12 +173,11 @@ private fun ResourcePatchContext.copyStringsXml(
         )?.let { inputStream ->
             val directory = "values-$language-v21"
             val valuesV21Directory = resourceDirectory.resolve(directory)
-            if (!valuesV21Directory.isDirectory) Files.createDirectories(valuesV21Directory.toPath())
+            if (!valuesV21Directory.isDirectory) valuesV21Directory.mkdirs()
 
-            Files.copy(
+            FilesCompat.copy(
                 inputStream,
-                resourceDirectory.resolve("$directory/strings.xml").toPath(),
-                StandardCopyOption.REPLACE_EXISTING
+                resourceDirectory.resolve("$directory/strings.xml")
             )
         }
     }

--- a/patches/src/main/kotlin/app/revanced/util/FilesCompat.kt
+++ b/patches/src/main/kotlin/app/revanced/util/FilesCompat.kt
@@ -8,12 +8,12 @@ import java.nio.file.StandardCopyOption
 /**
  * Provides java.nio.file.Files compatible functions.
  *
- * This is needed for ReVanced Manager running on Android 5.0-7.1
- * because before Android 8.0 does not have java.nio.file API.
+ * This is needed for the ReVanced Manager running on Android 5.0-7.1
+ * because Android 7.1 and below does not support the Java NIO2 Files API.
  */
 internal object FilesCompat {
     private val useCompat = try {
-        // Check existence of java.nio.file.Files class
+        // Check for the existence of java.nio.file.Files class
         Class.forName("java.nio.file.Files")
         false
     } catch (_ : ClassNotFoundException) {

--- a/patches/src/main/kotlin/app/revanced/util/FilesCompat.kt
+++ b/patches/src/main/kotlin/app/revanced/util/FilesCompat.kt
@@ -1,0 +1,53 @@
+package app.revanced.util
+
+import java.io.File
+import java.io.InputStream
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+
+/**
+ * Provides java.nio.file.Files compatible functions.
+ *
+ * This is needed for ReVanced Manager running on Android 5.0-7.1
+ * because before Android 8.0 does not have java.nio.file API.
+ */
+internal object FilesCompat {
+    private val useCompat = try {
+        // Check existence of java.nio.file.Files class
+        Class.forName("java.nio.file.Files")
+        false
+    } catch (_ : ClassNotFoundException) {
+        // Under Android 8.0
+        true
+    }
+
+    /**
+     * Copy a file to a target file.
+     *
+     * If the `target` file already exists, replace an existing file.
+     */
+    fun copy(source: File, target: File) {
+        if (useCompat) {
+            source.copyTo(target, overwrite = true)
+        } else {
+            Files.copy(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)
+        }
+    }
+
+    /**
+     * Copies all bytes from an input stream to a file.
+     *
+     * If the `target` file already exists, replace an existing file.
+     */
+    fun copy(source: InputStream, target: File) {
+        if (useCompat) {
+            source.use { inputStream ->
+                target.outputStream().use { outputStream ->
+                    inputStream.copyTo(outputStream)
+                }
+            }
+        } else {
+            Files.copy(source, target.toPath(), StandardCopyOption.REPLACE_EXISTING)
+        }
+    }
+}

--- a/patches/src/main/kotlin/app/revanced/util/ResourceUtils.kt
+++ b/patches/src/main/kotlin/app/revanced/util/ResourceUtils.kt
@@ -11,8 +11,6 @@ import org.w3c.dom.Node
 import org.w3c.dom.NodeList
 import java.io.File
 import java.io.InputStream
-import java.nio.file.Files
-import java.nio.file.StandardCopyOption
 
 private val classLoader = object {}.javaClass.classLoader
 
@@ -114,14 +112,9 @@ fun ResourcePatchContext.copyAdaptiveIcon(
         if (oldIconResourceFile != newIconResourceFile) {
             mipmapDirectories.forEach {
                 val mipmapDirectory = get("res").resolve(it)
-                Files.copy(
-                    mipmapDirectory
-                        .resolve("$oldIconResourceFile.png")
-                        .toPath(),
-                    mipmapDirectory
-                        .resolve("$newIconResourceFile.png")
-                        .toPath(),
-                    StandardCopyOption.REPLACE_EXISTING
+                FilesCompat.copy(
+                    mipmapDirectory.resolve("$oldIconResourceFile.png"),
+                    mipmapDirectory.resolve("$newIconResourceFile.png")
                 )
             }
         }
@@ -131,14 +124,9 @@ fun ResourcePatchContext.copyAdaptiveIcon(
         adaptiveIconMonoChromeFileName != getAdaptiveIconMonoChromeResourceFile()
     ) {
         val drawableDirectory = get("res").resolve("drawable")
-        Files.copy(
-            drawableDirectory
-                .resolve("$adaptiveIconMonoChromeFileName.xml")
-                .toPath(),
-            drawableDirectory
-                .resolve("${getAdaptiveIconMonoChromeResourceFile()}.xml")
-                .toPath(),
-            StandardCopyOption.REPLACE_EXISTING
+        FilesCompat.copy(
+            drawableDirectory.resolve("$adaptiveIconMonoChromeFileName.xml"),
+            drawableDirectory.resolve("${getAdaptiveIconMonoChromeResourceFile()}.xml")
         )
     }
 }
@@ -198,9 +186,9 @@ fun ResourcePatchContext.copyFile(
                 val toDirectory = resourceDirectory.resolve(group.resourceDirectoryName)
 
                 group.resources.forEach { iconFileName ->
-                    Files.write(
-                        toDirectory.resolve(iconFileName).toPath(),
-                        fromDirectory.resolve(iconFileName).readBytes()
+                    FilesCompat.copy(
+                        fromDirectory.resolve(iconFileName),
+                        toDirectory.resolve(iconFileName)
                     )
                 }
             }
@@ -304,16 +292,15 @@ fun ResourcePatchContext.copyResources(
         resourceGroup.resources.forEach { resource ->
             val resourceDirectoryName = resourceGroup.resourceDirectoryName
             val targetDirectory = resourceDirectory.resolve(resourceDirectoryName)
-            if (!targetDirectory.isDirectory) Files.createDirectories(targetDirectory.toPath())
+            if (!targetDirectory.isDirectory) targetDirectory.mkdirs()
             val resourceFile = "$resourceDirectoryName/$resource"
             inputStreamFromBundledResource(
                 sourceResourceDirectory,
                 resourceFile
             )?.let { inputStream ->
-                Files.copy(
+                FilesCompat.copy(
                     inputStream,
-                    resourceDirectory.resolve(resourceFile).toPath(),
-                    StandardCopyOption.REPLACE_EXISTING,
+                    resourceDirectory.resolve(resourceFile),
                 )
             }
         }


### PR DESCRIPTION
Support patching on Android 5-7 by adding Files API compatibility

I am not sure of the difference between `Files.copy()` and `Files.write()`
`Files.write()` is used in some part, but when I replaced the it to copy, it's working fine
Do you have any idea why `Files.write()` is used in some part?