### PR TITLE
chore(ResourceMappingPatch): Use the read-only version of document constructor

### DIFF
--- a/patches/src/main/kotlin/app/revanced/patches/shared/mapping/ResourceMappingPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/shared/mapping/ResourceMappingPatch.kt
@@ -24,7 +24,7 @@ val resourceMappingPatch = resourcePatch(
     description = "resourceMappingPatch"
 ) {
     execute {
-        document("res/values/public.xml").use { document ->
+        document(get("res/values/public.xml").inputStream()).use { document ->
             val resources = document.documentElement.childNodes
             val resourcesLength = resources.length
             resourceMappings = HashMap<String, ResourceElement>(2 * resourcesLength)


### PR DESCRIPTION
I once said that `document("res/values/public.xml")` is fine in the Patcher v21 PR, but this was incorrect.
Please see this:
https://github.com/ReVanced/revanced-patches/pull/4409#discussion_r2074852325

Since there is no patch to edit `public.xml`, It is better to not to re-output the XML file in ResourceMapingPatch.

Looking at the Javadoc comment in ResourcePatchContext, the one that receives a String path is `Read and write`, but the one that receives an InputStream is only `read`.
https://github.com/ReVanced/revanced-patcher/blob/ead701bdaf51f30ccefe846471bc2d3b550b7bdb/src/main/kotlin/app/revanced/patcher/patch/ResourcePatchContext.kt#L34-L42