### PR TITLE
fix(YouTube Music): Fix crashes on Android 5-6

### DIFF
--- a/extensions/shared/src/main/java/app/revanced/extension/music/patches/misc/AlbumMusicVideoPatch.java
+++ b/extensions/shared/src/main/java/app/revanced/extension/music/patches/misc/AlbumMusicVideoPatch.java
@@ -97,7 +97,7 @@ public class AlbumMusicVideoPatch {
             if (request == null) {
                 return;
             }
-            String songId = request.getStream();
+            String songId = request.getSongId();
             if (songId.isEmpty()) {
                 Logger.printDebug(() -> "Official song not found, videoId: " + videoId);
                 return;

--- a/extensions/shared/src/main/java/app/revanced/extension/music/patches/misc/requests/PlaylistRequest.kt
+++ b/extensions/shared/src/main/java/app/revanced/extension/music/patches/misc/requests/PlaylistRequest.kt
@@ -44,7 +44,7 @@ class PlaylistRequest private constructor(
         }
 
         // Only expired if the fetch failed (API null response).
-        return (fetchCompleted() && stream.isEmpty())
+        return (fetchCompleted() && songId.isEmpty())
     }
 
     /**
@@ -54,24 +54,24 @@ class PlaylistRequest private constructor(
         return future.isDone
     }
 
-    val stream: String
+    val songId: String
         get() {
             try {
                 return future[MAX_MILLISECONDS_TO_WAIT_FOR_FETCH, TimeUnit.MILLISECONDS]
             } catch (ex: TimeoutException) {
                 Logger.printInfo(
-                    { "getStream timed out" },
+                    { "getSongId timed out" },
                     ex
                 )
             } catch (ex: InterruptedException) {
                 Logger.printException(
-                    { "getStream interrupted" },
+                    { "getSongId interrupted" },
                     ex
                 )
                 Thread.currentThread().interrupt() // Restore interrupt status flag.
             } catch (ex: ExecutionException) {
                 Logger.printException(
-                    { "getStream failure" },
+                    { "getSongId failure" },
                     ex
                 )
             }
@@ -102,7 +102,7 @@ class PlaylistRequest private constructor(
                 if (isSDKAbove(24)) {
                     cache.values.removeIf { request ->
                         val expired = request.isExpired(now)
-                        if (expired) Logger.printDebug { "Removing expired stream: " + request.videoId }
+                        if (expired) Logger.printDebug { "Removing expired song id: " + request.videoId }
                         expired
                     }
                 } else {
@@ -110,7 +110,7 @@ class PlaylistRequest private constructor(
                     while (itr.hasNext()) {
                         val request = itr.next().value
                         if (request.isExpired(now)) {
-                            Logger.printDebug { "Removing expired stream: " + request.videoId }
+                            Logger.printDebug { "Removing expired song id: " + request.videoId }
                             itr.remove()
                         }
                     }

--- a/extensions/shared/src/main/java/app/revanced/extension/music/patches/misc/requests/PlaylistRequest.kt
+++ b/extensions/shared/src/main/java/app/revanced/extension/music/patches/misc/requests/PlaylistRequest.kt
@@ -98,7 +98,7 @@ class PlaylistRequest private constructor(
             Objects.requireNonNull(videoId)
             synchronized(cache) {
                 val now = System.currentTimeMillis()
-                cache.values.removeIf { request: PlaylistRequest ->
+                cache.values.removeAll { request ->
                     val expired = request.isExpired(now)
                     if (expired) Logger.printDebug { "Removing expired stream: " + request.videoId }
                     expired

--- a/extensions/shared/src/main/java/app/revanced/extension/music/patches/utils/DrawableColorPatch.java
+++ b/extensions/shared/src/main/java/app/revanced/extension/music/patches/utils/DrawableColorPatch.java
@@ -11,6 +11,8 @@ import org.apache.commons.lang3.ArrayUtils;
 
 import app.revanced.extension.shared.utils.ResourceUtils;
 
+import static app.revanced.extension.shared.utils.Utils.isSDKAbove;
+
 @SuppressWarnings("unused")
 public class DrawableColorPatch {
     private static final int[] DARK_COLORS = {
@@ -55,7 +57,7 @@ public class DrawableColorPatch {
         // headerGradient is litho, so this view is sometimes used elsewhere, like the button of the action bar.
         // In order to prevent the gradient to be applied to the button of the action bar,
         // Add a layout listener to the ImageView.
-        if (headerGradient != null && gradientView.getForeground() == null) {
+        if (isSDKAbove(23) && headerGradient != null && gradientView.getForeground() == null) {
             gradientView.setForeground(headerGradient);
             gradientView.getViewTreeObserver().addOnGlobalLayoutListener(() -> {
                 if (gradientView.getParent() instanceof View view &&

--- a/extensions/shared/src/main/java/app/revanced/extension/shared/patches/spoof/SpoofStreamingDataPatch.java
+++ b/extensions/shared/src/main/java/app/revanced/extension/shared/patches/spoof/SpoofStreamingDataPatch.java
@@ -2,6 +2,7 @@ package app.revanced.extension.shared.patches.spoof;
 
 import static app.revanced.extension.shared.innertube.utils.J2V8Support.supportJ2V8;
 import static app.revanced.extension.shared.innertube.utils.StreamingDataOuterClassUtils.prioritizeResolution;
+import static app.revanced.extension.shared.utils.Utils.isSDKAbove;
 
 import android.net.Uri;
 import android.text.TextUtils;
@@ -341,7 +342,11 @@ public class SpoofStreamingDataPatch {
     public static void initializeJavascript() {
         if (SPOOF_STREAMING_DATA_USE_JS) {
             // Download JavaScript and initialize the Cipher class
-            CompletableFuture.runAsync(ThrottlingParameterUtils::initializeJavascript);
+            if (isSDKAbove(24)) {
+                CompletableFuture.runAsync(ThrottlingParameterUtils::initializeJavascript);
+            } else {
+                Utils.runOnBackgroundThread(ThrottlingParameterUtils::initializeJavascript);
+            }
         }
     }
 

--- a/extensions/shared/src/main/java/app/revanced/extension/shared/settings/BaseHostActivity.java
+++ b/extensions/shared/src/main/java/app/revanced/extension/shared/settings/BaseHostActivity.java
@@ -3,6 +3,7 @@ package app.revanced.extension.shared.settings;
 import static app.revanced.extension.shared.utils.ResourceUtils.getIdIdentifier;
 import static app.revanced.extension.shared.utils.ResourceUtils.getLayoutIdentifier;
 import static app.revanced.extension.shared.utils.ResourceUtils.getStringIdentifier;
+import static app.revanced.extension.shared.utils.Utils.isSDKAbove;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
@@ -109,9 +110,11 @@ public abstract class BaseHostActivity extends Activity {
         toolbar.setNavigationOnClickListener(getNavigationClickListener(this));
         toolbar.setTitle(STRING_REVANCED_SETTINGS_TITLE);
 
-        final int margin = Utils.dipToPixels(16);
-        toolbar.setTitleMarginStart(margin);
-        toolbar.setTitleMarginEnd(margin);
+        if (isSDKAbove(24)) {
+            final int margin = Utils.dipToPixels(16);
+            toolbar.setTitleMarginStart(margin);
+            toolbar.setTitleMarginEnd(margin);
+        }
         TextView toolbarTextView = Utils.getChildView(toolbar, false, view -> view instanceof TextView);
         if (toolbarTextView != null) {
             toolbarTextView.setTextColor(BaseThemeUtils.getAppForegroundColor());

--- a/extensions/shared/src/main/java/app/revanced/extension/shared/settings/WebViewHostActivity.java
+++ b/extensions/shared/src/main/java/app/revanced/extension/shared/settings/WebViewHostActivity.java
@@ -228,9 +228,11 @@ public class WebViewHostActivity extends Activity {
         toolbar.setNavigationIcon(BaseThemeUtils.getBackButtonDrawable(false));
         toolbar.setNavigationOnClickListener(view -> this.finish());
         toolbar.setTitle(toolbarLabel);
-        final int margin = Utils.dipToPixels(16);
-        toolbar.setTitleMarginStart(margin);
-        toolbar.setTitleMarginEnd(margin);
+        if (isSDKAbove(24)) {
+            final int margin = Utils.dipToPixels(16);
+            toolbar.setTitleMarginStart(margin);
+            toolbar.setTitleMarginEnd(margin);
+        }
         TextView textView = Utils.getChildView(toolbar, view -> view instanceof TextView);
         if (textView != null) {
             textView.setTextColor(Color.BLACK);

--- a/extensions/shared/src/main/java/app/revanced/extension/shared/settings/preference/AbstractPreferenceFragment.java
+++ b/extensions/shared/src/main/java/app/revanced/extension/shared/settings/preference/AbstractPreferenceFragment.java
@@ -94,7 +94,7 @@ public abstract class AbstractPreferenceFragment extends PreferenceFragment {
                     showSettingUserDialogConfirmation(pref, setting);
                     return;
                 } else if (setting.rebootApp) {
-                    showRestartDialog(getContext());
+                    showRestartDialog(getActivity());
                 }
             }
 
@@ -130,7 +130,7 @@ public abstract class AbstractPreferenceFragment extends PreferenceFragment {
     private void showSettingUserDialogConfirmation(Preference pref, Setting<?> setting) {
         Utils.verifyOnMainThread();
 
-        final var context = getContext();
+        final var context = getActivity();
         if (confirmDialogTitle == null) {
             confirmDialogTitle = str("revanced_confirm_user_dialog_title");
         }


### PR DESCRIPTION
Fixed crashes on Android 5-6 caused by unsupported new APIs.

One concern was whether Kotlin's `removeAll` method of MutableMap could be used.
But testing on 6.20.51 and 8.30.54, I confirmed it works.